### PR TITLE
Fix static context indenting

### DIFF
--- a/src/main/java/com/github/abrarsyed/jastyle/ASBeautifier.java
+++ b/src/main/java/com/github/abrarsyed/jastyle/ASBeautifier.java
@@ -111,6 +111,7 @@ public class ASBeautifier extends AbstractASBase
     private char currentNonLegalCh;
     private char prevNonLegalCh;
     private boolean useProperInnerClassIndenting = true;
+    protected final IndentContext indentContext = new IndentContext(this.useProperInnerClassIndenting);
 
     // variables set by ASFormatter - must be updated in activeBeautifierStack
     protected int inLineNumber;
@@ -935,6 +936,9 @@ public class ASBeautifier extends AbstractASBase
             spaceTabCount = inStatementIndentStack.peek();
         }
 
+        indentContext.setStack(this.headerStack);
+        indentContext.setLine(originalLine.toString());
+
         for (int i = 0; i < headerStack.size(); i++)
         {
             isInClass = false;
@@ -948,9 +952,9 @@ public class ASBeautifier extends AbstractASBase
             }
             else if (!(i > 0 && !headerStack.get(i - 1).equals(ASResource.AS_OPEN_BRACKET) && headerStack.get(i).equals(ASResource.AS_OPEN_BRACKET)))
             {
-                if (!this.useProperInnerClassIndenting || !headerStack.get(i).equals(ASResource.AS_STATIC))
+                if (indentContext.tryIndent(i, tabCount))
                 {
-                    ++tabCount;
+                    tabCount = indentContext.getIndent();
                 }
             }
 

--- a/src/main/java/com/github/abrarsyed/jastyle/IndentContext.java
+++ b/src/main/java/com/github/abrarsyed/jastyle/IndentContext.java
@@ -76,6 +76,11 @@ final class IndentContext
                             this.indent = this.previousIndent + 1;
                         }
                     }
+                } else if(!ASResource.AS_STATIC.equals(this.stack.get(this.stack.size() - 2))) {
+                    this.indent++;
+                    if(this.stack.containsValue(ASResource.AS_STATIC) && this.frequency(ASResource.AS_CLASS) >= 2) {
+                        this.indent--;
+                    }
                 }
             }
             else
@@ -85,5 +90,15 @@ final class IndentContext
         }
 
         return true;
+    }
+
+    private int frequency(final String token) {
+        int result = 0;
+        for(Map.Entry<Integer, String> entry : this.stack.entrySet()) {
+            if(entry.getValue().equals(token)) {
+                result++;
+            }
+        }
+        return result;
     }
 }

--- a/src/main/java/com/github/abrarsyed/jastyle/IndentContext.java
+++ b/src/main/java/com/github/abrarsyed/jastyle/IndentContext.java
@@ -1,0 +1,89 @@
+package com.github.abrarsyed.jastyle;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Stack;
+
+final class IndentContext
+{
+    private final boolean useProperInnerClassIndenting;
+    private boolean reentryPermitted;
+    private Stack<String> headerStack; // This is not a copy.
+    private String line;
+    private int previousIndent;
+    private int indent;
+    private final Map<Integer, String> stack = new HashMap<Integer, String>();
+
+    IndentContext(boolean useProperInnerClassIndenting)
+    {
+        this.useProperInnerClassIndenting = useProperInnerClassIndenting;
+    }
+
+    void setStack(Stack<String> stack)
+    {
+        this.headerStack = stack;
+
+        // Copy to a map to avoid IOOBEs
+        this.stack.clear();
+        for (int i = 0; i < this.headerStack.size(); i++)
+        {
+            this.stack.put(i, this.headerStack.get(i));
+        }
+    }
+
+    void setLine(String line)
+    {
+        this.reentryPermitted = true;
+        this.line = line;
+        this.previousIndent = this.indent;
+    }
+
+    int getIndent()
+    {
+        return this.indent;
+    }
+
+    boolean tryIndent(final int index, final int tabCount)
+    {
+        if (!this.reentryPermitted)
+        {
+            return false;
+        }
+
+        this.indent = tabCount;
+
+        if (!this.useProperInnerClassIndenting)
+        {
+            this.indent++;
+        }
+        else
+        {
+            if (this.headerStack.contains(ASResource.AS_CLASS) && this.headerStack.contains(ASResource.AS_OPEN_BRACKET))
+            {
+                if (!this.headerStack.get(index).equals(ASResource.AS_STATIC) || (this.headerStack.size() >= index + 2 && this.headerStack.get(index + 1).equals(ASResource.AS_OPEN_BRACKET)))
+                {
+                    this.indent++;
+                }
+                else if (this.line.equals(ASResource.AS_OPEN_BRACKET) && ASResource.AS_STATIC.equals(this.stack.get(this.stack.size() - 1)) && ASResource.AS_OPEN_BRACKET.equals(this.stack.get(this.stack.size() - 2)))
+                {
+                    this.indent++;
+                    if (ASResource.AS_CLASS.equals(this.stack.get(this.stack.size() - 3)) && ASResource.AS_STATIC.equals(this.stack.get(this.stack.size() - 4)))
+                    {
+                        this.indent++;
+                        this.reentryPermitted = false;
+                        if (this.stack.size() > 3 && this.indent <= this.previousIndent)
+                        {
+                            this.indent = this.previousIndent + 1;
+                        }
+                    }
+                }
+            }
+            else
+            {
+                this.indent++;
+            }
+        }
+
+        return true;
+    }
+}


### PR DESCRIPTION
This is the real fix, unlike #7.

Before:
```java
    static class AIJohnnyAttack extends EntityAINearestAttackableTarget<EntityLivingBase>
        {
            public AIJohnnyAttack(EntityVindicator p_i47345_1_)
            {
                super(p_i47345_1_, EntityLivingBase.class, 0, true, true, EntityVindicator.field_190644_c);
            }

            public boolean func_75250_a()
            {
                return ((EntityVindicator)this.field_75299_d).field_190643_b && super.func_75250_a();
            }
        }
```

After:
```java
    static class AIJohnnyAttack extends EntityAINearestAttackableTarget<EntityLivingBase>
    {
        public AIJohnnyAttack(EntityVindicator p_i47345_1_)
        {
            super(p_i47345_1_, EntityLivingBase.class, 0, true, true, EntityVindicator.field_190644_c);
        }

        public boolean func_75250_a()
        {
            return ((EntityVindicator)this.field_75299_d).field_190643_b && super.func_75250_a();
        }
    }
```